### PR TITLE
fix duplicate values being added to dictionary when constructing $WapSettings

### DIFF
--- a/cWAP/cWAP.psm1
+++ b/cWAP/cWAP.psm1
@@ -541,9 +541,6 @@ class cWAPConfiguration
                     FederationServiceTrustCredential    = $this.Credential
                     CertificateThumbprint               = $this.CertificateThumbprint
                     FederationServiceName               = $this.FederationServiceName
-                    ForwardProxy                        = $this.ForwardProxy
-                    HttpsPort                           = $this.HttpsPort
-                    TlsClientPort                       = $this.TlsClientPort
                 }
 
                 if($this.ForwardProxy -ne $null){


### PR DESCRIPTION
This is to fix the construction of $WapSettings where the same keys are being added to it and an error gets thrown